### PR TITLE
Discord webhook and pass arguments from bash script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,135 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Config files
+config.json
+gclient.json
+.env
+

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/CVS-covid-vaccine-checker.iml
+++ b/.idea/CVS-covid-vaccine-checker.iml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,21 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="1">
+            <item index="0" class="java.lang.String" itemvalue="discord" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyPep8Inspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="E203" />
+        </list>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9 (CVS-covid-vaccine-checker)" project-jdk-type="Python SDK" />
+  <component name="PyCharmProfessionalAdvertiser">
+    <option name="shown" value="true" />
+  </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9 (CVS-covid-vaccine-checker)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/CVS-covid-vaccine-checker.iml" filepath="$PROJECT_DIR$/.idea/CVS-covid-vaccine-checker.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = ""

--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
-language = "bash"
+language = "python"
 run = "python vaccine.py"

--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
-language = "python3"
-run = "python vaccine.py"
+language = 'python3'
+run = 'python vaccine.py True 3 60 NY Elmsford Harrison Larchmont Mamaroneck Rye "Rye Brook" "White Plains"'

--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
-language = "python"
+language = "python3"
 run = "python vaccine.py"

--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
 language = "bash"
-run = ""
+run = "python vaccine.py"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,113 @@
+[[package]]
+name = "beepy"
+version = "1.0.7"
+description = "Play notification sounds."
+category = "main"
+optional = false
+python-versions = ">=3.0"
+
+[package.dependencies]
+simpleaudio = "*"
+
+[[package]]
+name = "certifi"
+version = "2020.12.5"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "chardet"
+version = "4.0.0"
+description = "Universal encoding detector for Python 2 and 3"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "idna"
+version = "2.10"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "requests"
+version = "2.25.1"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+chardet = ">=3.0.2,<5"
+idna = ">=2.5,<3"
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+
+[[package]]
+name = "simpleaudio"
+version = "1.0.4"
+description = "Simple, asynchronous audio playback for Python 3."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "urllib3"
+version = "1.26.4"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+brotli = ["brotlipy (>=0.6.0)"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.9"
+content-hash = "c923b53c9615662c94f987e7b520b6017dd14f4d61bf2b55d6048c62b63a9733"
+
+[metadata.files]
+beepy = [
+    {file = "beepy-1.0.7-py3-none-any.whl", hash = "sha256:0e6616ad678fcf334e57c00633676ffef0ce1232127855fb2fc62c91e67ddb06"},
+    {file = "beepy-1.0.7.tar.gz", hash = "sha256:817348ff3cc098aca8d1de7bc15292b762fde20fcc0a020fccea7936940d5b5f"},
+]
+certifi = [
+    {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
+    {file = "certifi-2020.12.5.tar.gz", hash = "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c"},
+]
+chardet = [
+    {file = "chardet-4.0.0-py2.py3-none-any.whl", hash = "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"},
+    {file = "chardet-4.0.0.tar.gz", hash = "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"},
+]
+idna = [
+    {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
+    {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
+]
+requests = [
+    {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},
+    {file = "requests-2.25.1.tar.gz", hash = "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"},
+]
+simpleaudio = [
+    {file = "simpleaudio-1.0.4-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:05b63da515f5fc7c6f40e4d9673d22239c5e03e2bda200fc09fd21c185d73713"},
+    {file = "simpleaudio-1.0.4-cp37-cp37m-win32.whl", hash = "sha256:f1a4fe3358429b2ea3181fd782e4c4fff5c123ca86ec7fc29e01ee9acd8a227a"},
+    {file = "simpleaudio-1.0.4-cp37-cp37m-win_amd64.whl", hash = "sha256:86f1b0985629852afe67259ac6c24905ca731cb202a6e96b818865c56ced0c27"},
+    {file = "simpleaudio-1.0.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f68820297ad51577e3a77369e7e9b23989d30d5ae923bf34c92cf983c04ade04"},
+    {file = "simpleaudio-1.0.4-cp38-cp38-win32.whl", hash = "sha256:67348e3d3ccbae73bd126beed7f1e242976889620dbc6974c36800cd286430fc"},
+    {file = "simpleaudio-1.0.4-cp38-cp38-win_amd64.whl", hash = "sha256:f346a4eac9cdbb1b3f3d0995095b7e86c12219964c022f4d920c22f6ca05fb4c"},
+    {file = "simpleaudio-1.0.4.tar.gz", hash = "sha256:691c88649243544db717e7edf6a9831df112104e1aefb5f6038a5d071e8cf41d"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.4-py2.py3-none-any.whl", hash = "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df"},
+    {file = "urllib3-1.26.4.tar.gz", hash = "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"},
+]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,45 +1,45 @@
 [[package]]
-name = "beepy"
-version = "1.0.7"
-description = "Play notification sounds."
 category = "main"
+description = "Play notification sounds."
+name = "beepy"
 optional = false
 python-versions = ">=3.0"
+version = "1.0.7"
 
 [package.dependencies]
 simpleaudio = "*"
 
 [[package]]
-name = "certifi"
-version = "2020.12.5"
-description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
+description = "Python package for providing Mozilla's CA Bundle."
+name = "certifi"
 optional = false
 python-versions = "*"
+version = "2020.12.5"
 
 [[package]]
-name = "chardet"
-version = "4.0.0"
-description = "Universal encoding detector for Python 2 and 3"
 category = "main"
+description = "Universal encoding detector for Python 2 and 3"
+name = "chardet"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "4.0.0"
 
 [[package]]
-name = "idna"
-version = "2.10"
-description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
+description = "Internationalized Domain Names in Applications (IDNA)"
+name = "idna"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.10"
 
 [[package]]
-name = "requests"
-version = "2.25.1"
-description = "Python HTTP for Humans."
 category = "main"
+description = "Python HTTP for Humans."
+name = "requests"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.25.1"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
@@ -49,33 +49,32 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
-socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
 
 [[package]]
-name = "simpleaudio"
-version = "1.0.4"
-description = "Simple, asynchronous audio playback for Python 3."
 category = "main"
+description = "Simple, asynchronous audio playback for Python 3."
+name = "simpleaudio"
 optional = false
 python-versions = "*"
+version = "1.0.4"
 
 [[package]]
-name = "urllib3"
-version = "1.26.4"
-description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "1.26.4"
 
 [package.extras]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 brotli = ["brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [metadata]
-lock-version = "1.1"
-python-versions = "^3.9"
 content-hash = "c923b53c9615662c94f987e7b520b6017dd14f4d61bf2b55d6048c62b63a9733"
+python-versions = "^3.9"
 
 [metadata.files]
 beepy = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "cvs-covid-vaccine-checker"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <you@example.com>"]
+license = "Apache-2.0"
+
+[tool.poetry.dependencies]
+python = "^3.9"
+requests = "^2.25.1"
+beepy = "^1.0.7"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/vaccine.py
+++ b/vaccine.py
@@ -66,9 +66,11 @@ def find_a_vaccine(discord: bool = False, hours_to_run: int = 3, refresh: int = 
             for item in payload["responsePayloadData"]["data"][state]:
                 mappings[item.get('city')] = item.get('status')
 
+            print('Checking the internets.')
             print(time.ctime())
-            for city in cities:
-                print(city + ":", mappings[city.upper()])
+            if discord is False:
+                for city in cities:
+                    print(city + ":", mappings[city.upper()])
 
             for key in mappings.keys():
                 if (key.capitalize() in cities) and (mappings[key] != 'Fully Booked'):

--- a/vaccine.py
+++ b/vaccine.py
@@ -9,14 +9,16 @@ If you receive an error that says something is not install, type
 pip install beepy
 
 in your terminal.
+
+To use with a Discord webhook, save the webhook in your .env as webhook="<your url here>"
 """
 
 
 from typing import List
+from os import environ
 import requests
 import time
-from os import environ
-# import beepy
+import beepy
 from discord import Webhook, RequestsWebhookAdapter
 from flask import Flask
 from threading import Thread
@@ -27,7 +29,7 @@ app = Flask('')
 
 @app.route('/')
 def main():
-    return "Your Bot Is Ready"
+    return "Your webhook is ready"
 
 
 def run():
@@ -39,7 +41,8 @@ def keep_alive():
     server.start()
 
 
-def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', cities: List[str] = ['Chicago']):
+def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', cities: List[str] = ['Chicago'],
+                   discord: bool = False):
     state = state.upper()
     states = ["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DC", "DE", "FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY",
               "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH",
@@ -68,9 +71,11 @@ def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', 
 
             for key in mappings.keys():
                 if (key.capitalize() in cities) and (mappings[key] != 'Fully Booked'):
-                    # beepy.beep(sound='coin')  # repl won't run the script since it doesn't have the sound files
-                    webhook = Webhook.from_url(environ['webhook'], adapter=RequestsWebhookAdapter())
-                    webhook.send(key.capitalize() + " has an opening!")
+                    if discord:
+                        webhook = Webhook.from_url(environ['webhook'], adapter=RequestsWebhookAdapter())
+                        webhook.send(key.capitalize() + " has an opening!")
+                    else:
+                        beepy.beep(sound='coin')
                     break
                 else:
                     pass
@@ -84,5 +89,5 @@ keep_alive()
 
 # this final line runs the function
 # your terminal will output the Chicago, IL every 60 seconds for 3 hours by default if no arguments are passed
-find_a_vaccine(3, 60, 'ny', ['Elmsford', 'Harrison', 'Larchmont', 'Mamaroneck', 'Rye', 'Rye Brook', 'White Plains'])
+find_a_vaccine(3, 60, 'NY', ['Elmsford', 'Harrison', 'Larchmont', 'Mamaroneck', 'Rye', 'Rye Brook', 'White Plains'], True)
 

--- a/vaccine.py
+++ b/vaccine.py
@@ -90,8 +90,11 @@ keep_alive()
 
 # this final line runs the function
 # your terminal will output the Chicago, IL every 60 seconds for 3 hours by default if no arguments are passed
-# find_a_vaccine(True, 3, 60, 'NY', ['Elmsford', 'Harrison', 'Larchmont', 'Mamaroneck', 'Rye', 'Rye Brook', 'White Plains'])
+# find_a_vaccine(True,3,60,'NY',['Elmsford','Harrison','Larchmont','Mamaroneck','Rye','Rye Brook','White Plains'])
 a = sys.argv
 n = len(a)
-c = a[5:n]
-find_a_vaccine(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], c)
+if n > 1:
+    c = a[5:n]
+    find_a_vaccine(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], c)
+else:
+    find_a_vaccine()

--- a/vaccine.py
+++ b/vaccine.py
@@ -43,7 +43,7 @@ def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', 
 
             print(time.ctime())
             for city in cities:
-                print(city + ":", mappings[city])
+                print(city + ":", mappings[city.upper()])
 
             for key in mappings.keys():
                 if (key in cities) and (mappings[key] != 'Fully Booked'):
@@ -58,5 +58,5 @@ def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', 
 
 # this final line runs the function
 # your terminal will output the Chicago, IL every 60 seconds for 3 hours by default if no arguments are passed
-find_a_vaccine(3, 60, 'ny', ['Rye', 'White Plains'])
+find_a_vaccine(3, 60, 'ny', ['Elmsford', 'Harrison', 'Larchmont', 'Mamaroneck', 'Rye', 'Rye Brook', 'White Plains'])
 

--- a/vaccine.py
+++ b/vaccine.py
@@ -54,7 +54,8 @@ def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', 
             time.sleep(refresh)
             print('\n')
 
+
 # this final line runs the function
 # your terminal will output the Chicago, IL every 60 seconds for 3 hours by default if no arguments are passed
-find_a_vaccine()
+find_a_vaccine(3, 60, 'ny', ['Rye', 'White Plains'])
 

--- a/vaccine.py
+++ b/vaccine.py
@@ -42,8 +42,8 @@ def keep_alive():
     server.start()
 
 
-def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', cities: List[str] = ['Chicago'],
-                   discord: bool = False):
+def find_a_vaccine(discord: bool = False, hours_to_run: int = 3, refresh: int = 60, state: str = 'IL',
+                   cities: List[str] = ['Chicago']):
     state = state.upper()
     states = ["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DC", "DE", "FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY",
               "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH",
@@ -90,5 +90,8 @@ keep_alive()
 
 # this final line runs the function
 # your terminal will output the Chicago, IL every 60 seconds for 3 hours by default if no arguments are passed
-# find_a_vaccine(3, 60, 'NY', ['Elmsford', 'Harrison', 'Larchmont', 'Mamaroneck', 'Rye', 'Rye Brook', 'White Plains'], True)
-find_a_vaccine(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
+# find_a_vaccine(True, 3, 60, 'NY', ['Elmsford', 'Harrison', 'Larchmont', 'Mamaroneck', 'Rye', 'Rye Brook', 'White Plains'])
+a = sys.argv
+n = len(a)
+c = a[5:n]
+find_a_vaccine(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], c)

--- a/vaccine.py
+++ b/vaccine.py
@@ -22,10 +22,10 @@ def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', 
     states = ["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DC", "DE", "FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY",
               "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH",
               "OK", "OR", "PA", "PR", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY"]
-    if (state not in states) or (state.length() != 2):
+    if (state not in states) or (len(state) != 2):
         print("Please enter a valid state abbreviation.")
         return
-    elif cities.length < 1:
+    elif len(cities) < 1:
         print("Please enter at least one city.")
         return
     else:
@@ -33,7 +33,7 @@ def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', 
         while time.time() < max_time:
 
             response = requests.get("https://www.cvs.com/immunizations/covid-19-vaccine.vaccine-status.{}.json?vaccineinfo"
-                                    .format(state.lower()), headers={"Referer": "https://www.cvs.com/immunizations/covid-19-vaccine"})
+                                    .format(state.upper()), headers={"Referer": "https://www.cvs.com/immunizations/covid-19-vaccine"})
             payload = response.json()
 
             mappings = {}
@@ -42,7 +42,7 @@ def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', 
 
             print(time.ctime())
             for city in cities:
-                print(city, mappings[city])
+                print(city + ":", mappings[city])
 
             for key in mappings.keys():
                 if (key in cities) and (mappings[key] != 'Fully Booked'):

--- a/vaccine.py
+++ b/vaccine.py
@@ -16,8 +16,27 @@ from typing import List
 import requests
 import time
 from os import environ
-import beepy
+# import beepy
 from discord import Webhook, RequestsWebhookAdapter
+from flask import Flask
+from threading import Thread
+
+# code to keep got awake when being web-hosted on Repl.it
+app = Flask('')
+
+
+@app.route('/')
+def main():
+    return "Your Bot Is Ready"
+
+
+def run():
+    app.run(host="0.0.0.0", port=8000)
+
+
+def keep_alive():
+    server = Thread(target=run)
+    server.start()
 
 
 def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', cities: List[str] = ['Chicago']):
@@ -49,7 +68,7 @@ def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', 
 
             for key in mappings.keys():
                 if (key.capitalize() in cities) and (mappings[key] != 'Fully Booked'):
-                    beepy.beep(sound='coin')
+                    # beepy.beep(sound='coin')  # repl won't run the script since it doesn't have the sound files
                     webhook = Webhook.from_url(environ['webhook'], adapter=RequestsWebhookAdapter())
                     webhook.send(key.capitalize() + " has an opening!")
                     break
@@ -59,6 +78,9 @@ def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', 
             time.sleep(refresh)
             print('\n')
 
+
+# this will run Flask and let UptimeRobot keep the webhooks going
+keep_alive()
 
 # this final line runs the function
 # your terminal will output the Chicago, IL every 60 seconds for 3 hours by default if no arguments are passed

--- a/vaccine.py
+++ b/vaccine.py
@@ -82,7 +82,7 @@ def find_a_vaccine(discord: bool = False, hours_to_run: int = 3, refresh: int = 
                     pass
 
             time.sleep(refresh)
-            print('\n')
+            print('Checking the internets.\n')
 
 
 # this will run Flask and let UptimeRobot keep the webhooks going

--- a/vaccine.py
+++ b/vaccine.py
@@ -15,11 +15,9 @@ in your terminal.
 from typing import List
 import requests
 import time
-import os
+from os import environ
 import beepy
 from discord import Webhook, RequestsWebhookAdapter
-
-url = os.getenv('webhook')
 
 
 def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', cities: List[str] = ['Chicago']):
@@ -50,10 +48,10 @@ def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', 
                 print(city + ":", mappings[city.upper()])
 
             for key in mappings.keys():
-                if (key in cities) and (mappings[key] != 'Fully Booked'):
+                if (key.capitalize() in cities) and (mappings[key] != 'Fully Booked'):
                     beepy.beep(sound='coin')
-                    webhook = Webhook.from_url(url, adapter=RequestsWebhookAdapter())
-                    webhook.send(key + " has an opening!")
+                    webhook = Webhook.from_url(environ['webhook'], adapter=RequestsWebhookAdapter())
+                    webhook.send(key.capitalize() + " has an opening!")
                     break
                 else:
                     pass

--- a/vaccine.py
+++ b/vaccine.py
@@ -16,6 +16,7 @@ To use with a Discord webhook, save the webhook in your .env as webhook="<your u
 
 from typing import List
 from os import environ
+import sys
 import requests
 import time
 import beepy
@@ -89,5 +90,5 @@ keep_alive()
 
 # this final line runs the function
 # your terminal will output the Chicago, IL every 60 seconds for 3 hours by default if no arguments are passed
-find_a_vaccine(3, 60, 'NY', ['Elmsford', 'Harrison', 'Larchmont', 'Mamaroneck', 'Rye', 'Rye Brook', 'White Plains'], True)
-
+# find_a_vaccine(3, 60, 'NY', ['Elmsford', 'Harrison', 'Larchmont', 'Mamaroneck', 'Rye', 'Rye Brook', 'White Plains'], True)
+find_a_vaccine(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])

--- a/vaccine.py
+++ b/vaccine.py
@@ -12,12 +12,13 @@ in your terminal.
 """
 
 
+from typing import List
 import requests
 import time
 import beepy
 
 
-def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', cities: list[str] = ['Chicago']):
+def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', cities: List[str] = ['Chicago']):
     state = state.upper()
     states = ["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DC", "DE", "FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY",
               "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH",

--- a/vaccine.py
+++ b/vaccine.py
@@ -12,48 +12,47 @@ in your terminal.
 '''
 
 
-
 import requests
 import time
 import beepy
 
 
-def findAVaccine(hours_to_run: int = 3, state: str = 'IL', cities: List[str] = ['Chicago']):
-  state = state.upper()
-  # hours_to_run = 3 ###Update this to set the number of hours you want the script to run.
-  states = ["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DC", "DE", "FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "PR", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY"]
-  if (state not in states) or (state.length() != 2):
-    print("Please enter a valid state abbreviation.")
-    return
-  elif cities.length < 1:
-    print("Please enter at least one city.")
-    return
-  else:
-    max_time = time.time() + hours_to_run*60*60
-    while time.time() < max_time:
+def findAVaccine(hours_to_run: int = 3, state: str = 'IL', cities: list[str] = ['Chicago']):
+    state = state.upper()
+    # hours_to_run = 3 ###Update this to set the number of hours you want the script to run.
+    states = ["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DC", "DE", "FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "PR", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY"]
+    if (state not in states) or (state.length() != 2):
+        print("Please enter a valid state abbreviation.")
+        return
+    elif cities.length < 1:
+        print("Please enter at least one city.")
+        return
+    else:
+        max_time = time.time() + hours_to_run*60*60
+        while time.time() < max_time:
 
-        # state = 'IL' ###Update with your state abbreviation. Be sure to use all CAPS, e.g. RI
+            # state = 'IL' ###Update with your state abbreviation. Be sure to use all CAPS, e.g. RI
 
-        response = requests.get("https://www.cvs.com/immunizations/covid-19-vaccine.vaccine-status.{}.json?vaccineinfo".format(state.lower()), headers={"Referer":"https://www.cvs.com/immunizations/covid-19-vaccine"})
-        payload = response.json()
+            response = requests.get("https://www.cvs.com/immunizations/covid-19-vaccine.vaccine-status.{}.json?vaccineinfo".format(state.lower()), headers={"Referer":"https://www.cvs.com/immunizations/covid-19-vaccine"})
+            payload = response.json()
 
-        mappings = {}
-        for item in payload["responsePayloadData"]["data"][state]:
-            mappings[item.get('city')] = item.get('status')
+            mappings = {}
+            for item in payload["responsePayloadData"]["data"][state]:
+                mappings[item.get('city')] = item.get('status')
 
-        print(time.ctime())
-        # cities = ['BELLEVILLE', 'CHICAGO', 'DEKALB', 'WAUKEGAN'] ###Update with your cities nearby
-        for city in cities:
-            print(city, mappings[city])
+            print(time.ctime())
+            # cities = ['BELLEVILLE', 'CHICAGO', 'DEKALB', 'WAUKEGAN'] ###Update with your cities nearby
+            for city in cities:
+                print(city, mappings[city])
 
-        for key in mappings.keys():
-            if (key in cities) and (mappings[key] != 'Fully Booked'):
-                beepy.beep(sound = 'coin')
-                break
-            else:
-                pass
+            for key in mappings.keys():
+                if (key in cities) and (mappings[key] != 'Fully Booked'):
+                    beepy.beep(sound = 'coin')
+                    break
+                else:
+                    pass
 
-        time.sleep(60) ##This runs every 60 seconds. Update here if you'd like it to go every 10min (600sec)
-        print('\n')
+            time.sleep(60) ##This runs every 60 seconds. Update here if you'd like it to go every 10min (600sec)
+            print('\n')
 
 findAVaccine() ###this final line runs the function. Your terminal will output the cities every 60seconds

--- a/vaccine.py
+++ b/vaccine.py
@@ -18,12 +18,21 @@ import time
 import beepy
 
 
-def findAVaccine():
-    hours_to_run = 3 ###Update this to set the number of hours you want the script to run.
+def findAVaccine(hours_to_run: int = 3, state: str = 'IL', cities: List[str] = ['Chicago']):
+  state = state.upper()
+  # hours_to_run = 3 ###Update this to set the number of hours you want the script to run.
+  states = ["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DC", "DE", "FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "PR", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY"]
+  if (state not in states) or (state.length() != 2):
+    print("Please enter a valid state abbreviation.")
+    return
+  elif cities.length < 1:
+    print("Please enter at least one city.")
+    return
+  else:
     max_time = time.time() + hours_to_run*60*60
     while time.time() < max_time:
 
-        state = 'IL' ###Update with your state abbreviation. Be sure to use all CAPS, e.g. RI
+        # state = 'IL' ###Update with your state abbreviation. Be sure to use all CAPS, e.g. RI
 
         response = requests.get("https://www.cvs.com/immunizations/covid-19-vaccine.vaccine-status.{}.json?vaccineinfo".format(state.lower()), headers={"Referer":"https://www.cvs.com/immunizations/covid-19-vaccine"})
         payload = response.json()
@@ -33,7 +42,7 @@ def findAVaccine():
             mappings[item.get('city')] = item.get('status')
 
         print(time.ctime())
-        cities = ['BELLEVILLE', 'CHICAGO', 'DEKALB', 'WAUKEGAN'] ###Update with your cities nearby
+        # cities = ['BELLEVILLE', 'CHICAGO', 'DEKALB', 'WAUKEGAN'] ###Update with your cities nearby
         for city in cities:
             print(city, mappings[city])
 

--- a/vaccine.py
+++ b/vaccine.py
@@ -95,6 +95,6 @@ a = sys.argv
 n = len(a)
 if n > 1:
     c = a[5:n]
-    find_a_vaccine(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], c)
+    find_a_vaccine(sys.argv[1], int(sys.argv[2]), int(sys.argv[3]), sys.argv[4], c)
 else:
     find_a_vaccine()

--- a/vaccine.py
+++ b/vaccine.py
@@ -1,4 +1,4 @@
-'''
+"""
 This is a python script that requires you have python installed, or in a cloud environment.
 
 This script scrapes the CVS website looking for vaccine appointments in the cities you list.
@@ -9,7 +9,7 @@ If you receive an error that says something is not install, type
 pip install beepy
 
 in your terminal.
-'''
+"""
 
 
 import requests
@@ -17,10 +17,11 @@ import time
 import beepy
 
 
-def findAVaccine(hours_to_run: int = 3, state: str = 'IL', cities: list[str] = ['Chicago']):
+def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', cities: list[str] = ['Chicago']):
     state = state.upper()
-    # hours_to_run = 3 ###Update this to set the number of hours you want the script to run.
-    states = ["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DC", "DE", "FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "PR", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY"]
+    states = ["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DC", "DE", "FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY",
+              "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH",
+              "OK", "OR", "PA", "PR", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY"]
     if (state not in states) or (state.length() != 2):
         print("Please enter a valid state abbreviation.")
         return
@@ -31,9 +32,8 @@ def findAVaccine(hours_to_run: int = 3, state: str = 'IL', cities: list[str] = [
         max_time = time.time() + hours_to_run*60*60
         while time.time() < max_time:
 
-            # state = 'IL' ###Update with your state abbreviation. Be sure to use all CAPS, e.g. RI
-
-            response = requests.get("https://www.cvs.com/immunizations/covid-19-vaccine.vaccine-status.{}.json?vaccineinfo".format(state.lower()), headers={"Referer":"https://www.cvs.com/immunizations/covid-19-vaccine"})
+            response = requests.get("https://www.cvs.com/immunizations/covid-19-vaccine.vaccine-status.{}.json?vaccineinfo"
+                                    .format(state.lower()), headers={"Referer": "https://www.cvs.com/immunizations/covid-19-vaccine"})
             payload = response.json()
 
             mappings = {}
@@ -41,18 +41,20 @@ def findAVaccine(hours_to_run: int = 3, state: str = 'IL', cities: list[str] = [
                 mappings[item.get('city')] = item.get('status')
 
             print(time.ctime())
-            # cities = ['BELLEVILLE', 'CHICAGO', 'DEKALB', 'WAUKEGAN'] ###Update with your cities nearby
             for city in cities:
                 print(city, mappings[city])
 
             for key in mappings.keys():
                 if (key in cities) and (mappings[key] != 'Fully Booked'):
-                    beepy.beep(sound = 'coin')
+                    beepy.beep(sound='coin')
                     break
                 else:
                     pass
 
-            time.sleep(60) ##This runs every 60 seconds. Update here if you'd like it to go every 10min (600sec)
+            time.sleep(refresh)
             print('\n')
 
-findAVaccine() ###this final line runs the function. Your terminal will output the cities every 60seconds
+# this final line runs the function
+# your terminal will output the Chicago, IL every 60 seconds for 3 hours by default if no arguments are passed
+find_a_vaccine()
+

--- a/vaccine.py
+++ b/vaccine.py
@@ -62,5 +62,5 @@ def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', 
 
 # this final line runs the function
 # your terminal will output the Chicago, IL every 60 seconds for 3 hours by default if no arguments are passed
-find_a_vaccine(3, 60, 'ny', ['Cortland', 'Elmsford', 'Harrison', 'Larchmont', 'Mamaroneck', 'Rye', 'Rye Brook', 'White Plains'])
+find_a_vaccine(3, 60, 'ny', ['Elmsford', 'Harrison', 'Larchmont', 'Mamaroneck', 'Rye', 'Rye Brook', 'White Plains'])
 

--- a/vaccine.py
+++ b/vaccine.py
@@ -82,7 +82,7 @@ def find_a_vaccine(discord: bool = False, hours_to_run: int = 3, refresh: int = 
                     pass
 
             time.sleep(refresh)
-            print('Checking the internets.\n')
+            print('\n')
 
 
 # this will run Flask and let UptimeRobot keep the webhooks going

--- a/vaccine.py
+++ b/vaccine.py
@@ -15,7 +15,11 @@ in your terminal.
 from typing import List
 import requests
 import time
+import os
 import beepy
+from discord import Webhook, RequestsWebhookAdapter
+
+url = os.getenv('webhook')
 
 
 def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', cities: List[str] = ['Chicago']):
@@ -31,7 +35,7 @@ def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', 
         return
     else:
         max_time = time.time() + hours_to_run*60*60
-        while time.time() < max_time:
+        while time.time() < max_time:  # change to True to run indefinitely after deployed with Flask
 
             response = requests.get("https://www.cvs.com/immunizations/covid-19-vaccine.vaccine-status.{}.json?vaccineinfo"
                                     .format(state.upper()), headers={"Referer": "https://www.cvs.com/immunizations/covid-19-vaccine"})
@@ -48,6 +52,8 @@ def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', 
             for key in mappings.keys():
                 if (key in cities) and (mappings[key] != 'Fully Booked'):
                     beepy.beep(sound='coin')
+                    webhook = Webhook.from_url(url, adapter=RequestsWebhookAdapter())
+                    webhook.send(key + " has an opening!")
                     break
                 else:
                     pass
@@ -58,5 +64,5 @@ def find_a_vaccine(hours_to_run: int = 3, refresh: int = 60, state: str = 'IL', 
 
 # this final line runs the function
 # your terminal will output the Chicago, IL every 60 seconds for 3 hours by default if no arguments are passed
-find_a_vaccine(3, 60, 'ny', ['Elmsford', 'Harrison', 'Larchmont', 'Mamaroneck', 'Rye', 'Rye Brook', 'White Plains'])
+find_a_vaccine(3, 60, 'ny', ['Cortland', 'Elmsford', 'Harrison', 'Larchmont', 'Mamaroneck', 'Rye', 'Rye Brook', 'White Plains'])
 


### PR DESCRIPTION
Added in capacity to send messages to a Discord webhook, as well as passing arguments from bash script, added `.gitignore` to not share the webhook url stored in `.env`, added `.replit` for executing the bash when deploying on repl.it, added `pyproject.toml` to manage dependencies and for repl.it to load them