### PR TITLE
Handle whitespace in city names via city file. Fixes #11 and #13.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,24 @@ This should be easy enough for someone comfortable with technology. Ask for help
 Run the script with your chosen state and list of cities. For example, to search for appointments in NJ in the cities of Princeton and Plainsboro, run
 
 ```bash
-python vaccine.py python vaccine.py --state NJ --cities princeton plainsboro
+python vaccine.py --state NJ --cities princeton plainsboro "Belle Mead"
 ```
 
 You will see output like this:
 
 ```
 Tue Mar 30 12:43:37 2021
+BELLE MEAD Fully Booked
 PLAINSBORO Fully Booked
 PRINCETON Fully Booked
 ```
+
+Alternatively, you can put the cities in a text file, one per line, and use:
+```bash
+python vaccine.py --state NJ --cityfile cities.txt
+```
+
+To find the list of cities, select your state at [CVS immunizations](https://www.cvs.com/immunizations/covid-19-vaccine).
 
 By default, the script will check for appointments every minute and run for a total of 3 hours after which it will exit. To change these values, you can use specify `--total` and `--refresh` options respectively. Run `python vaccine.py --help` for details.
 

--- a/cities.txt
+++ b/cities.txt
@@ -1,0 +1,14 @@
+reston
+herndon
+sterling
+great falls
+falls church
+baileys crossroads
+ashburn
+centreville
+chantilly
+arlington
+alexandria
+annandale
+fairfax
+burke

--- a/vaccine.py
+++ b/vaccine.py
@@ -37,13 +37,20 @@ def main():  # noqa: D103
     parser.add_argument("--state",
                         help="State to search, e.g., NJ",
                         required=True)
-    parser.add_argument("--cities",
-                        nargs='+',
-                        help="Full names of cities to search, separated by whitespace",
-                        required=True)
+    citygroup = parser.add_mutually_exclusive_group(required=True)
+    citygroup.add_argument("--cities",
+                            nargs='+',
+                            help="Full names of cities to search, separated by whitespace. "
+                           "Quote multiword cities like 'Falls Church'.")
+    citygroup.add_argument("--cityfile",
+                           help="Filename with cities, one per line.",
+                           type=argparse.FileType('r'))
+
 
     # parse given command line arguments
     args = parser.parse_args()
+    if args.cityfile:
+        args.cities = [x.strip() for x in args.cityfile.readlines()]
 
     max_time = time.time() + args.total_hours * 60 * 60
     state_url = CVS_URL.format(args.state.lower())


### PR DESCRIPTION
Note that quoting also works on the command line, eg `... --cities "Belle Mead" princeton`.
